### PR TITLE
feat(assembly): add more assemblers

### DIFF
--- a/languages/assembly_fasm/Dockerfile
+++ b/languages/assembly_fasm/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+
+RUN apk add --no-cache curl && \
+    curl -sL "https://flatassembler.net/fasm-1.73.30.tgz" | tar xz && \
+    ln -s /fasm/fasm.x64 /usr/local/bin/fasm.x64
+
+COPY run.sh /var/run

--- a/languages/assembly_fasm/Dockerfile
+++ b/languages/assembly_fasm/Dockerfile
@@ -1,7 +1,10 @@
-FROM alpine
+FROM alpine as build
 
 RUN apk add --no-cache curl && \
     curl -sL "https://flatassembler.net/fasm-1.73.30.tgz" | tar xz && \
     ln -s /fasm/fasm.x64 /usr/local/bin/fasm.x64
 
+FROM alpine
+
+COPY --from=build /fasm/fasm.x64 /usr/local/bin
 COPY run.sh /var/run

--- a/languages/assembly_fasm/run.sh
+++ b/languages/assembly_fasm/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+printf %s"\n" "$1" > program.s
+fasm.x64 program.s program >&2
+echo "$2" > .input
+shift 2
+./program "$@" < .input

--- a/languages/assembly_gcc/Dockerfile
+++ b/languages/assembly_gcc/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+
+RUN apk add --no-cache gcc musl-dev
+COPY run.sh /var/run

--- a/languages/assembly_gcc/run.sh
+++ b/languages/assembly_gcc/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+printf %s"\n" "$1" > program.s
+gcc -no-pie -o program program.s
+echo "$2" > .input
+shift 2
+./program "$@" < .input

--- a/languages/assembly_gcc/run.sh
+++ b/languages/assembly_gcc/run.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 printf %s"\n" "$1" > program.s
-gcc -no-pie -o program program.s
+gcc -nostdlib -nostartfiles -nodefaultlibs -static -c -o .obj program.s
+ld -o program -static .obj
 echo "$2" > .input
 shift 2
 ./program "$@" < .input

--- a/languages/assembly_jwasm/Dockerfile
+++ b/languages/assembly_jwasm/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine
+
+RUN apk add --no-cache build-base cmake git && \
+    git clone https://github.com/JWasm/JWasm.git && \
+    cd JWasm && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    ln -s /JWasm/build/jwasm /usr/bin
+
+COPY run.sh /var/run

--- a/languages/assembly_jwasm/Dockerfile
+++ b/languages/assembly_jwasm/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine as build
 
 RUN apk add --no-cache build-base cmake git && \
     git clone https://github.com/JWasm/JWasm.git && \
@@ -6,7 +6,10 @@ RUN apk add --no-cache build-base cmake git && \
     mkdir build && \
     cd build && \
     cmake .. && \
-    make && \
-    ln -s /JWasm/build/jwasm /usr/bin
+    make
 
+FROM alpine
+
+RUN apk add --no-cache binutils
+COPY --from=build /JWasm/build/jwasm /usr/local/bin
 COPY run.sh /var/run

--- a/languages/assembly_jwasm/run.sh
+++ b/languages/assembly_jwasm/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+printf %s"\n" "$1" > program.s
+jwasm -elf64 -Fo .obj program.s >&2
+ld -o program .obj
+echo "$2" > .input
+shift 2
+./program "$@" < .input

--- a/languages/spim/Dockerfile
+++ b/languages/spim/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine as build
+
+RUN apk add --no-cache build-base bison flex git && \
+    git clone https://github.com/TryItOnline/spim.git /opt/spim && \
+    cd /opt/spim && \
+    make && \
+    chmod -R 755 /opt/spim
+
+COPY run.sh /var/run

--- a/languages/spim/run.sh
+++ b/languages/spim/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+printf %s"\n" "$1" > program.s
+echo "$2" > .input
+shift 2
+/opt/spim/spim -file program.s "$@" < .input

--- a/src/routes/eval.rs
+++ b/src/routes/eval.rs
@@ -292,6 +292,7 @@ mod test {
         assembly_as, "assembly_as.s";
         assembly_fasm, "assembly_fasm.s";
         assembly_gcc, "assembly_gcc.s";
+        assembly_jwasm, "assembly_jwasm.s";
         assembly_nasm, "assembly_nasm.s";
         bash, "bash.sh";
         befunge, "befunge.b93";

--- a/src/routes/eval.rs
+++ b/src/routes/eval.rs
@@ -290,6 +290,7 @@ mod test {
 
     gen_test! {
         assembly_as, "assembly_as.s";
+        assembly_fasm, "assembly_fasm.s";
         assembly_nasm, "assembly_nasm.s";
         bash, "bash.sh";
         befunge, "befunge.b93";

--- a/src/routes/eval.rs
+++ b/src/routes/eval.rs
@@ -317,6 +317,7 @@ mod test {
         ruby, "ruby.rb";
         rust, "rust.rs";
         shakespeare, "shakespeare.spl";
+        spim, "spim.s";
         sqlite, "sqlite.sql";
         typescript, "typescript.ts";
     }

--- a/src/routes/eval.rs
+++ b/src/routes/eval.rs
@@ -291,6 +291,7 @@ mod test {
     gen_test! {
         assembly_as, "assembly_as.s";
         assembly_fasm, "assembly_fasm.s";
+        assembly_gcc, "assembly_gcc.s";
         assembly_nasm, "assembly_nasm.s";
         bash, "bash.sh";
         befunge, "befunge.b93";

--- a/test-programs/assembly_fasm.s
+++ b/test-programs/assembly_fasm.s
@@ -1,0 +1,13 @@
+format ELF executable 3
+
+_start:
+	mov eax, 4
+	mov ebx, 1
+	mov ecx, msg
+	mov edx, 13
+	int      0x80
+	mov eax, 1
+    mov ebx, 0
+    int 0x80
+ 
+msg db "Hello, World!"

--- a/test-programs/assembly_gcc.s
+++ b/test-programs/assembly_gcc.s
@@ -1,13 +1,19 @@
-SYS_write = 4
-STDOUT = 1
-.data
-hello:
-.string "Hello, World!"
-.globl main
-main:
-movl $SYS_write,%eax
-movl $STDOUT,%ebx
-movl $hello,%ecx
-movl $13,%edx
-int $0x80
-ret
+.global _start
+
+.text
+
+_start:
+    # write (1, msj, 13)
+    mov $1, %rax            # system call 1 is write
+    mov $1, %rdi            # file handler 1 is stdout
+    mov $message, %rsi      # address of string to output
+    mov $13, %rdx           # number of bytes
+    syscall
+
+    # exit(0)
+    mov $60, %rax           # system call 60 is exit
+    xor %rdi, %rdi          # we want to return code 0
+    syscall
+
+message:
+    .ascii "Hello, World!\n"

--- a/test-programs/assembly_gcc.s
+++ b/test-programs/assembly_gcc.s
@@ -1,0 +1,14 @@
+SYS_write = 4
+STDOUT = 1
+.data
+hello:
+.string "Hello, World!"
+.globl main
+main:
+movl $SYS_write,%eax
+movl $STDOUT,%ebx
+movl $hello,%ecx
+movl $13,%edx
+int $0x80
+ret
+

--- a/test-programs/assembly_gcc.s
+++ b/test-programs/assembly_gcc.s
@@ -11,4 +11,3 @@ movl $hello,%ecx
 movl $13,%edx
 int $0x80
 ret
-

--- a/test-programs/assembly_jwasm.s
+++ b/test-programs/assembly_jwasm.s
@@ -1,0 +1,14 @@
+.data
+output db "Hello, World!"
+
+.code
+_start:
+	mov eax, 4
+	mov ebx, 1
+	lea ecx, output
+	mov edx, 13
+	int      80h
+	mov eax, 1
+	mov ebx, 0
+	int      80h
+end _start

--- a/test-programs/spim.s
+++ b/test-programs/spim.s
@@ -1,0 +1,12 @@
+	.data
+msg:
+	.asciiz "Hello, World!"
+
+
+	.text
+main:
+	li $v0, 4
+	la $a0, msg
+	syscall
+	li $v0, 10
+	syscall


### PR DESCRIPTION
This PR adds more assembly assemblers:

- [x] [`fasm`](https://flatassembler.net/)
- [x] [`gcc`](https://gcc.gnu.org/)
- [x] [`JWasm`](https://github.com/JWasm/JWasm)
- [x] [`spim` (MIPS)](http://spimsimulator.sourceforge.net/)
